### PR TITLE
Unit tests for Blob, Table, Queue Storage, Azure WebApps, Azure Networks

### DIFF
--- a/tests/test-azure-blob-storage.js
+++ b/tests/test-azure-blob-storage.js
@@ -1,0 +1,59 @@
+const azureStorageX = require("../storage/blob-storage");
+const nock = require("nock");
+const azureStorage = new azureStorageX();
+
+const containerName = "nodecloud-unit-test";
+
+describe("Azure Blob Storage", () => {
+  it("should create container", done => {
+    azureStorage
+      .create(containerName, { publicAccessLevel: "blob" })
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should list containers", done => {
+    azureStorage
+      .list(null, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should upload to container", done => {
+    azureStorage
+      .upload(containerName, "unit-test-blob", "./package.json", {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete container", done => {
+    azureStorage
+      .delete(containerName, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+});

--- a/tests/test-azure-blob-storage.js
+++ b/tests/test-azure-blob-storage.js
@@ -1,4 +1,6 @@
 const azureStorageX = require("../storage/blob-storage");
+const chai = require("chai");
+const assert = chai.assert;
 const nock = require("nock");
 const azureStorage = new azureStorageX();
 
@@ -9,7 +11,7 @@ describe("Azure Blob Storage", () => {
     azureStorage
       .create(containerName, { publicAccessLevel: "blob" })
       .then(res => {
-        console.log(res);
+        assert.isOk("nodecloud-unit-test", res.name);
         done();
       })
       .catch(err => {
@@ -22,7 +24,7 @@ describe("Azure Blob Storage", () => {
     azureStorage
       .list(null, {})
       .then(res => {
-        console.log(res);
+        assert.isOk(1, res.entries.len);
         done();
       })
       .catch(err => {
@@ -35,7 +37,7 @@ describe("Azure Blob Storage", () => {
     azureStorage
       .upload(containerName, "unit-test-blob", "./package.json", {})
       .then(res => {
-        console.log(res);
+        assert.isOk("unit-test-blob", res.name);
         done();
       })
       .catch(err => {
@@ -48,7 +50,7 @@ describe("Azure Blob Storage", () => {
     azureStorage
       .delete(containerName, {})
       .then(res => {
-        console.log(res);
+        assert.isOk(true, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-network.js
+++ b/tests/test-azure-network.js
@@ -1,4 +1,6 @@
 const nock = require("nock");
+const chai = require("chai");
+const assert = chai.assert;
 const msRestAzure = require("ms-rest-azure");
 const azureNx = require("../network/azure-virtual-network");
 const azureNetwork = new azureNx(msRestAzure);
@@ -38,6 +40,7 @@ describe("Azure Network", () => {
       .create("nodeCloud-unit", "unittestnetwork", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -61,6 +64,7 @@ describe("Azure Network", () => {
       .delete("nodecloud-unit", "unittestnetwork", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -84,6 +88,7 @@ describe("Azure Network", () => {
       .get("nodecloud-unit", "unittestnetwork", {})
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -107,6 +112,7 @@ describe("Azure Network", () => {
       .list("nodecloud-unit")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -130,6 +136,7 @@ describe("Azure Network", () => {
       .createSubnet("nodecloud", "unittestnetwork", "unitestsubnet", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -153,6 +160,7 @@ describe("Azure Network", () => {
       .deleteSubnet("nodecloud", "unittestnetwork", "unittestsubnet", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -176,6 +184,7 @@ describe("Azure Network", () => {
       .createSecurityGroup("nodecloud", "unittestgroup", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -199,6 +208,7 @@ describe("Azure Network", () => {
       .deleteSecurityGroup("nodecloud", "unittestgroup", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -222,6 +232,7 @@ describe("Azure Network", () => {
       .createLoadBalancer("nodecloud", "unitestsloadbalancer", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -245,6 +256,7 @@ describe("Azure Network", () => {
       .deleteLoadBalancer("nodecloud", "unitestsloadbalancer", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -273,6 +285,7 @@ describe("Azure Network", () => {
       )
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -301,6 +314,7 @@ describe("Azure Network", () => {
       )
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-network.js
+++ b/tests/test-azure-network.js
@@ -10,6 +10,18 @@ const params = {
   }
 };
 
+const securityRulesParams = {
+  location: "centralus",
+  protocol: "Tcp",
+  direction: "Inbound",
+  priority: 100,
+  access: "Allow",
+  sourcePortRange: "*",
+  destinationPortRange: "*",
+  sourceAddressPrefix: "*",
+  destinationAddressPrefix: "*"
+};
+
 describe("Azure Network", () => {
   it("should create virtual network", done => {
     nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
@@ -24,6 +36,269 @@ describe("Azure Network", () => {
 
     azureNetwork
       .create("nodeCloud-unit", "unittestnetwork", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete virtual network", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud-unit/providers/Microsoft.Network/virtualNetworks/unittestnetwork?api-version=2018-02-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .delete("nodecloud-unit", "unittestnetwork", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should get the details of network", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud-unit/providers/Microsoft.Network/virtualNetworks/unittestnetwork?api-version=2018-02-01"
+    )
+      .get(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .get("nodecloud-unit", "unittestnetwork", {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should get the list of networks", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud-unit/providers/Microsoft.Network/virtualNetworks?api-version=2018-02-01"
+    )
+      .get(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .list("nodecloud-unit")
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should create subnet in the network", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/virtualNetworks/unittestnetwork/subnets/unitestsubnet?api-version=2018-02-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .createSubnet("nodecloud", "unittestnetwork", "unitestsubnet", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete subnet from the network", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/virtualNetworks/unittestnetwork/subnets/unittestsubnet?api-version=2018-02-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .deleteSubnet("nodecloud", "unittestnetwork", "unittestsubnet", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should create security group", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/networkSecurityGroups/unittestgroup?api-version=2018-02-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .createSecurityGroup("nodecloud", "unittestgroup", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete security group", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/networkSecurityGroups/unittestgroup?api-version=2018-02-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .deleteSecurityGroup("nodecloud", "unittestgroup", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should create loadbalancer", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/loadBalancers/unitestsloadbalancer?api-version=2018-02-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .createLoadBalancer("nodecloud", "unitestsloadbalancer", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete loadbalancer", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/loadBalancers/unitestsloadbalancer?api-version=2018-02-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .deleteLoadBalancer("nodecloud", "unitestsloadbalancer", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should create security rule", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/networkSecurityGroups/unittestnetwork/securityRules/unittestrule?api-version=2018-02-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .createSecurityRule(
+        "nodecloud",
+        "unittestnetwork",
+        "unittestrule",
+        securityRulesParams
+      )
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete security rule", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7f/resourceGroups/nodecloud/providers/Microsoft.Network/networkSecurityGroups/unittestnetwork/securityRules/unittestrule?api-version=2018-02-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .deleteSecurityRule(
+        "nodecloud",
+        "unittestnetwork",
+        "unittestrule",
+        securityRulesParams
+      )
       .then(res => {
         console.log(res);
         done();

--- a/tests/test-azure-network.js
+++ b/tests/test-azure-network.js
@@ -39,7 +39,6 @@ describe("Azure Network", () => {
     azureNetwork
       .create("nodeCloud-unit", "unittestnetwork", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -63,7 +62,6 @@ describe("Azure Network", () => {
     azureNetwork
       .delete("nodecloud-unit", "unittestnetwork", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -87,7 +85,6 @@ describe("Azure Network", () => {
     azureNetwork
       .get("nodecloud-unit", "unittestnetwork", {})
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -111,7 +108,6 @@ describe("Azure Network", () => {
     azureNetwork
       .list("nodecloud-unit")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -135,7 +131,6 @@ describe("Azure Network", () => {
     azureNetwork
       .createSubnet("nodecloud", "unittestnetwork", "unitestsubnet", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -159,7 +154,6 @@ describe("Azure Network", () => {
     azureNetwork
       .deleteSubnet("nodecloud", "unittestnetwork", "unittestsubnet", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -183,7 +177,6 @@ describe("Azure Network", () => {
     azureNetwork
       .createSecurityGroup("nodecloud", "unittestgroup", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -207,7 +200,6 @@ describe("Azure Network", () => {
     azureNetwork
       .deleteSecurityGroup("nodecloud", "unittestgroup", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -231,7 +223,6 @@ describe("Azure Network", () => {
     azureNetwork
       .createLoadBalancer("nodecloud", "unitestsloadbalancer", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -255,7 +246,6 @@ describe("Azure Network", () => {
     azureNetwork
       .deleteLoadBalancer("nodecloud", "unitestsloadbalancer", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -284,7 +274,6 @@ describe("Azure Network", () => {
         securityRulesParams
       )
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -313,7 +302,6 @@ describe("Azure Network", () => {
         securityRulesParams
       )
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })

--- a/tests/test-azure-network.js
+++ b/tests/test-azure-network.js
@@ -1,0 +1,36 @@
+const nock = require("nock");
+const msRestAzure = require("ms-rest-azure");
+const azureNx = require("../network/azure-virtual-network");
+const azureNetwork = new azureNx(msRestAzure);
+
+const params = {
+  location: "centralus",
+  addressSpace: {
+    addressPrefixes: ["10.0.0.0/16"]
+  }
+};
+
+describe("Azure Network", () => {
+  it("should create virtual network", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/resourceGroups/nodeCloud-unit/providers/Microsoft.Network/virtualNetworks/unittestnetwork?api-version=2018-02-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+
+    azureNetwork
+      .create("nodeCloud-unit", "unittestnetwork", params)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+});

--- a/tests/test-azure-queue-storage.js
+++ b/tests/test-azure-queue-storage.js
@@ -1,4 +1,6 @@
 const azureStorageX = require("../storage/queue-storage");
+const chai = require("chai");
+const assert = chai.assert;
 const azureStorage = new azureStorageX();
 
 const queueName = "nodecloud-unit-test-queue";
@@ -8,7 +10,8 @@ describe("Azure Queue Storage", () => {
     azureStorage
       .create(queueName)
       .then(res => {
-        console.log(res);
+        assert.isOk(queueName, res.name);
+        assert.isOk(true, res.created);
         done();
       })
       .catch(err => {
@@ -21,7 +24,7 @@ describe("Azure Queue Storage", () => {
     azureStorage
       .insert(queueName, "test-message", {})
       .then(res => {
-        console.log(res);
+        assert.notEqual(res, null);
         done();
       })
       .catch(err => {
@@ -33,7 +36,7 @@ describe("Azure Queue Storage", () => {
     azureStorage
       .peek(queueName, {})
       .then(res => {
-        console.log(res);
+        assert.isOk("test-message", res.messageText);
         done();
       })
       .catch(err => {
@@ -45,7 +48,7 @@ describe("Azure Queue Storage", () => {
     azureStorage
       .delete(queueName, {})
       .then(res => {
-        console.log(res);
+        assert.isOk(true, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-queue-storage.js
+++ b/tests/test-azure-queue-storage.js
@@ -1,4 +1,3 @@
-const nock = require("nock");
 const azureStorageX = require("../storage/queue-storage");
 const azureStorage = new azureStorageX();
 

--- a/tests/test-azure-queue-storage.js
+++ b/tests/test-azure-queue-storage.js
@@ -1,0 +1,56 @@
+const nock = require("nock");
+const azureStorageX = require("../storage/queue-storage");
+const azureStorage = new azureStorageX();
+
+const queueName = "nodecloud-unit-test-queue";
+
+describe("Azure Queue Storage", () => {
+  it("should create a queue", done => {
+    azureStorage
+      .create(queueName)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should insert a message", done => {
+    azureStorage
+      .insert(queueName, "test-message", {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should peek for message", done => {
+    azureStorage
+      .peek(queueName, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should delete a queue", done => {
+    azureStorage
+      .delete(queueName, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+});

--- a/tests/test-azure-table-storage.js
+++ b/tests/test-azure-table-storage.js
@@ -1,0 +1,63 @@
+const azureStorageX = require("../storage/table-storage");
+const azureStorage = new azureStorageX();
+const tableName = "nodecloudunittesttable";
+const task = {
+  PartitionKey: { _: "hometasks" },
+  RowKey: { _: "1" },
+  description: { _: "take out the trash" },
+  dueDate: { _: new Date(2015, 6, 20), $: "Edm.DateTime" }
+};
+
+describe("Azure Table Storage", () => {
+  it("should create table", done => {
+    azureStorage
+      .create(tableName, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should insert entity", done => {
+    azureStorage
+      .insert(tableName, task, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should retrieveEntity", done => {
+    azureStorage
+      .retrieveEntity(tableName, task.PartitionKey._, task.RowKey._, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+
+  it("should delete table", done => {
+    azureStorage
+      .delete(tableName, {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+        done();
+      });
+  });
+});

--- a/tests/test-azure-table-storage.js
+++ b/tests/test-azure-table-storage.js
@@ -1,4 +1,6 @@
 const azureStorageX = require("../storage/table-storage");
+const chai = require("chai");
+const assert = chai.assert;
 const azureStorage = new azureStorageX();
 const tableName = "nodecloudunittesttable";
 const task = {
@@ -13,7 +15,9 @@ describe("Azure Table Storage", () => {
     azureStorage
       .create(tableName, {})
       .then(res => {
-        console.log(res);
+        assert.isOk(true, res.isSuccessful);
+        assert.isOk(204, res.statusCode);
+        assert.isOk(tableName, res.TableName);
         done();
       })
       .catch(err => {
@@ -26,7 +30,7 @@ describe("Azure Table Storage", () => {
     azureStorage
       .insert(tableName, task, {})
       .then(res => {
-        console.log(res);
+        assert.notEqual(null, res);
         done();
       })
       .catch(err => {
@@ -39,7 +43,7 @@ describe("Azure Table Storage", () => {
     azureStorage
       .retrieveEntity(tableName, task.PartitionKey._, task.RowKey._, {})
       .then(res => {
-        console.log(res);
+        assert.notEqual(null, res);
         done();
       })
       .catch(err => {
@@ -52,7 +56,7 @@ describe("Azure Table Storage", () => {
     azureStorage
       .delete(tableName, {})
       .then(res => {
-        console.log(res);
+        assert.isOk(true, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-vm.js
+++ b/tests/test-azure-vm.js
@@ -1,4 +1,6 @@
 const nock = require("nock");
+const chai = require("chai");
+const assert = chai.assert;
 const msRestAzure = require("ms-rest-azure");
 const azureVMx = require("../compute/virtual-machine");
 const azureVM = new azureVMx(msRestAzure);
@@ -48,6 +50,7 @@ describe("Azure VM", () => {
       .list("nodecloud")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(res => {
@@ -70,6 +73,7 @@ describe("Azure VM", () => {
       .createOrUpdate("nodecloudtest", "testVM", params)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -92,6 +96,7 @@ describe("Azure VM", () => {
       .start("nodecloudtest", "testVM")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -113,6 +118,7 @@ describe("Azure VM", () => {
       .stop("nodecloudtest", "testVM")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -135,6 +141,7 @@ describe("Azure VM", () => {
       .destroy("nodecloudtest", "testVM")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -157,6 +164,7 @@ describe("Azure VM", () => {
       .reboot("nodecloudtest", "testVM")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-vm.js
+++ b/tests/test-azure-vm.js
@@ -1,7 +1,6 @@
-const chai = require("chai");
 const nock = require("nock");
 const msRestAzure = require("ms-rest-azure");
-const azureVMx = require("../compute/virtual_machine");
+const azureVMx = require("../compute/virtual-machine");
 const azureVM = new azureVMx(msRestAzure);
 const params = {
   location: "centralus",

--- a/tests/test-azure-vm.js
+++ b/tests/test-azure-vm.js
@@ -49,7 +49,6 @@ describe("Azure VM", () => {
     azureVM
       .list("nodecloud")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -72,7 +71,6 @@ describe("Azure VM", () => {
     azureVM
       .createOrUpdate("nodecloudtest", "testVM", params)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -95,7 +93,6 @@ describe("Azure VM", () => {
     azureVM
       .start("nodecloudtest", "testVM")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -117,7 +114,6 @@ describe("Azure VM", () => {
     azureVM
       .stop("nodecloudtest", "testVM")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -140,7 +136,6 @@ describe("Azure VM", () => {
     azureVM
       .destroy("nodecloudtest", "testVM")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -163,7 +158,6 @@ describe("Azure VM", () => {
     azureVM
       .reboot("nodecloudtest", "testVM")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })

--- a/tests/test-azure-webapps.js
+++ b/tests/test-azure-webapps.js
@@ -1,4 +1,6 @@
 const nock = require("nock");
+const chai = require("chai");
+const assert = chai.assert;
 const msRestAzure = require("ms-rest-azure");
 const azureWebAppsx = require("../webapps/app-service");
 const azureWebApps = new azureWebAppsx(msRestAzure);
@@ -29,6 +31,7 @@ describe("Azure WebApps", () => {
       .list("nodecloud")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -50,6 +53,7 @@ describe("Azure WebApps", () => {
       .createHostingPlan("nodecloud", "nodecloud-unit-test", planParameters)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -71,6 +75,7 @@ describe("Azure WebApps", () => {
       .createWebSite("nodecloud", "nodecloud-test-website", planParameters)
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -92,6 +97,7 @@ describe("Azure WebApps", () => {
       .getWebsite("nodecloyd-name", "Node")
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {
@@ -114,6 +120,7 @@ describe("Azure WebApps", () => {
       .deleteWebSite("nodecloud", "apps", {})
       .then(res => {
         console.log(res);
+        assert.isOk({}, res);
         done();
       })
       .catch(err => {

--- a/tests/test-azure-webapps.js
+++ b/tests/test-azure-webapps.js
@@ -30,7 +30,6 @@ describe("Azure WebApps", () => {
     azureWebApps
       .list("nodecloud")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -52,7 +51,6 @@ describe("Azure WebApps", () => {
     azureWebApps
       .createHostingPlan("nodecloud", "nodecloud-unit-test", planParameters)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -74,7 +72,6 @@ describe("Azure WebApps", () => {
     azureWebApps
       .createWebSite("nodecloud", "nodecloud-test-website", planParameters)
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -96,7 +93,6 @@ describe("Azure WebApps", () => {
     azureWebApps
       .getWebsite("nodecloyd-name", "Node")
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })
@@ -119,7 +115,6 @@ describe("Azure WebApps", () => {
     azureWebApps
       .deleteWebSite("nodecloud", "apps", {})
       .then(res => {
-        console.log(res);
         assert.isOk({}, res);
         done();
       })

--- a/tests/test-azure-webapps.js
+++ b/tests/test-azure-webapps.js
@@ -1,0 +1,123 @@
+const nock = require("nock");
+const msRestAzure = require("ms-rest-azure");
+const azureWebAppsx = require("../webapps/app-service");
+const azureWebApps = new azureWebAppsx(msRestAzure);
+
+const planParameters = {
+  appServicePlanName: "nodecloud-unit-test",
+  location: "centralus",
+  sku: {
+    name: "S1",
+    capacity: 1,
+    tier: "Standard"
+  }
+};
+
+describe("Azure WebApps", () => {
+  it("should list webapps", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/providers/Microsoft.Web/sites?api-version=2016-08-01"
+    )
+      .get(/$/)
+      .reply(200, {});
+
+    azureWebApps
+      .list("nodecloud")
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should create hosting plan", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/resourceGroups/nodecloud/providers/Microsoft.Web/serverfarms/nodecloud-unit-test?api-version=2016-09-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+    azureWebApps
+      .createHostingPlan("nodecloud", "nodecloud-unit-test", planParameters)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should create website", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/resourceGroups/nodecloud/providers/Microsoft.Web/sites/nodecloud-test-website?api-version=2016-08-01"
+    )
+      .put(/$/)
+      .reply(200, {});
+    azureWebApps
+      .createWebSite("nodecloud", "nodecloud-test-website", planParameters)
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should get details of website", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/resourceGroups/nodecloyd-name/providers/Microsoft.Web/sites/Node?api-version=2016-08-01"
+    )
+      .get(/$/)
+      .reply(200, {});
+    azureWebApps
+      .getWebsite("nodecloyd-name", "Node")
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+
+  it("should delete Website", done => {
+    nock("https://management.azure.com/subscriptions?api-version=2016-06-01")
+      .get(/$/)
+      .reply(200, {});
+
+    nock(
+      "https://management.azure.com/subscriptions/df36ec36-848f-44d6-88bb-2ced94baa7fd/resourceGroups/nodecloud/providers/Microsoft.Web/sites/apps?api-version=2016-08-01"
+    )
+      .delete(/$/)
+      .reply(200, {});
+
+    azureWebApps
+      .deleteWebSite("nodecloud", "apps", {})
+      .then(res => {
+        console.log(res);
+        done();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  });
+});


### PR DESCRIPTION
@rajikaimal 
For storage tests I was not able to add nock because there are some internal calls that azure-sdk does and some information such as requestId, etag, etc is expected in response, which can only be generated by azure known algorithm. I am not able to mock those.

Please review this PR