### PR TITLE
Change package name from nodecloud-azure to nodecloud-azure-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodecloud-azure",
+  "name": "nodecloud-azure-plugin",
   "version": "1.0.0",
   "description": "Azure Wrapper for NodeCloud Core",
   "main": "index.js",


### PR DESCRIPTION
Fixes #22 
 1. Change package name from nodecloud-azure to nodecloud-azure-plugin